### PR TITLE
Fixing sequel disconnect errors due to phusion passenger smart spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository deploys [Pact Broker](https://github.com/bethesque/pact_broker) 
 * Use `-p 80:80` to start the docker image, as some of the Rack middleware gets confused by receiving requests for other ports and will return a 404 otherwise (port forwarding does not rewrite headers).
 * On OSX, use `boot2docker ip` to get the IP of the VirtualBox, and connect on port 80.
 * ~~On OSX you need to use 8080 due to boot2docker's virtual box generally not having the right priviliges to start a new process listing to default web port.~~ This doesn't seem to be true/true anymore.
-* Currently, the application makes use of thin, but you can update the Gemfile to use any application server you like.
+* The application makes use of the phusion passenger application server.
 * As the native dependencies for a postgres driver are baked into the docker container, you are limited to using postgres as a database.
 * Apart from creating a postgres database no futher prepartion is required.
 

--- a/pact_broker/Gemfile
+++ b/pact_broker/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem "pact_broker"
 gem "pg"
-gem "thin" # Keep, or replace with your choice of web server
+gem "passenger"

--- a/pact_broker/Gemfile.lock
+++ b/pact_broker/Gemfile.lock
@@ -27,13 +27,11 @@ GEM
     awesome_print (1.6.1)
     blockenspiel (0.4.5)
     builder (3.2.2)
-    daemons (1.1.9)
     diff-lcs (1.2.5)
     disposable (0.0.9)
       representable (~> 2.0)
       uber
     erubis (2.7.0)
-    eventmachine (1.0.7)
     find_a_port (1.0.1)
     haml (4.0.6)
       tilt
@@ -108,6 +106,9 @@ GEM
       thor (~> 0.18)
     padrino-support (0.12.4)
       activesupport (>= 3.1)
+    passenger (5.0.20)
+      rack
+      rake (>= 0.8.1)
     pg (0.17.1)
     rack (1.6.4)
     rack-protection (1.5.3)
@@ -122,6 +123,7 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rake (10.4.2)
     randexp (0.1.7)
     redcarpet (3.3.2)
     reform (1.2.6)
@@ -155,10 +157,6 @@ GEM
       tilt (>= 1.3, < 3)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
-    thin (1.6.3)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0)
-      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
@@ -187,7 +185,7 @@ PLATFORMS
 DEPENDENCIES
   pact_broker
   pg
-  thin
+  passenger
 
 BUNDLED WITH
    1.10.5

--- a/pact_broker/config.ru
+++ b/pact_broker/config.ru
@@ -10,6 +10,14 @@ class DatabaseLogger < SimpleDelegator
   end
 end
 
+if defined?(PhusionPassenger)
+  PhusionPassenger.on_event(:starting_worker_process) do |forked|
+    if forked
+      Sequel::DATABASES.each { |db| db.disconnect }
+    end
+  end
+end
+
 DATABASE_CREDENTIALS = {
   adapter: "postgres",
   user: ENV['PACT_BROKER_DATABASE_USERNAME'],


### PR DESCRIPTION
I ran into some issues with the postgresql connection resulting in the error "Sequel::DatabaseDisconnectError: PG::ConnectionBad: PQconsumeInput()". After a bit of google searching it looks as if it is related to Phusion Passenger's smart spawing method (enabled by default).

More Info:
https://groups.google.com/forum/#!topic/sequel-talk/kh-MX2IoZwg
https://www.phusionpassenger.com/library/indepth/ruby/spawn_methods/#smart-spawning-hooks