### PR TITLE
Set the default logging verbosity to WARN

### DIFF
--- a/pact_broker/config.ru
+++ b/pact_broker/config.ru
@@ -24,6 +24,7 @@ app = PactBroker::App.new do | config |
   # config.auto_migrate_db = true
   # config.use_hal_browser = true
   config.logger = ::Logger.new($stdout)
+  config.logger.level = Logger::WARN
   config.database_connection = Sequel.connect(DATABASE_CREDENTIALS.merge(logger: DatabaseLogger.new(config.logger), encoding: 'utf8'))
 end
 


### PR DESCRIPTION
The default verbosity of the logs feels a little too noisy.