### PR TITLE
Upgrade to phusion/passenger-ruby22:0.9.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 sudo: required
 
-# Language and ruby version is not relevant because it runs inside
-# docker which has an specific ruby version installed in our Dockerfile
-# but left this here for the sake of Travis happiness
-language: ruby
-ruby:
-  - "2.2"
-
 services:
   - docker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM phusion/passenger-ruby22:0.9.15
+# ubuntu:14.04 -- https://hub.docker.com/_/ubuntu/
+# |==> phusion/baseimage:0.9.17 -- https://goo.gl/ZLt61q
+#      |==> phusion/passenger-ruby22:0.9.17 -- https://goo.gl/xsnWOP
+#           |==> HERE
+FROM phusion/passenger-ruby22:0.9.17
 
 EXPOSE 80
 ENV APP_HOME=/home/app/pact_broker


### PR DESCRIPTION
Bump passenger from 0.9.15 to 0.9.17

Also fixes [this](https://travis-ci.org/elgalu/pact_broker-docker/builds/87883855#L151) error by removing ruby as part of the build given we use ruby inside the container and not in the Travis host machine
> Couldn't find Ruby 2.2 ... ERROR 404: Not Found ... !!! unknown Ruby: 2.2
