### PR TITLE
Add support for docker native on OSX

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -79,9 +79,13 @@ if [ "$(uname)" == "Darwin" ]; then
     if [ "true" == "$(command -v docker-machine > /dev/null 2>&1 && echo 'true' || echo 'false')" ]; then
       test_ip=$(docker-machine ip default)
     else
-      echo "Cannot detect either boot2docker or docker-machine" && exit 1
+      if  [ "true" == "$(command -v docker > /dev/null 2>&1 && echo 'true' || echo 'false')" ]; then
+        test_ip='localhost'
+      else
+        echo "Cannot detect either boot2docker, docker-machine, or docker native" && exit 1
     fi
   fi
+fi
 else
   PORT_BIND="${PACT_BROKER_PORT}"
 fi


### PR DESCRIPTION
[Docker for Mac](https://docs.docker.com/engine/installation/mac/) is now an option for OSX along with boot2docker and docker-machine.
This PR updates the test script to check for the `docker` command on OSX and assigns the test_ip to localhost if found.
