### PR TITLE
Upgrade to ruby 2.4 and fix the docker storage problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # |==> phusion/baseimage:0.9.17 -- https://goo.gl/ZLt61q
 #      |==> phusion/passenger-ruby22:0.9.17 -- https://goo.gl/xsnWOP
 #           |==> HERE
-FROM phusion/passenger-ruby22:0.9.17
+FROM phusion/passenger-ruby24:0.9.26
 
 EXPOSE 80
 ENV APP_HOME=/home/app/pact_broker

--- a/container/etc/nginx/sites-enabled/webapp.conf
+++ b/container/etc/nginx/sites-enabled/webapp.conf
@@ -7,5 +7,5 @@ server {
     passenger_user app;
 
     # If this is a Ruby app, specify a Ruby version:
-    passenger_ruby /usr/bin/ruby2.2;
+    passenger_ruby /usr/bin/ruby;
 }


### PR DESCRIPTION
Should resolve https://github.com/DiUS/pact_broker-docker/issues/49

We needed this upgrade to be able to support this docker image on a kubernetes cluster.