### PR TITLE
Reduce Docker image size from 906 to 769 MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,19 @@
-# ubuntu:14.04 -- https://hub.docker.com/_/ubuntu/
+# ubuntu:16.04 -- https://hub.docker.com/_/ubuntu/
 # |==> phusion/baseimage:0.9.17 -- https://goo.gl/ZLt61q
-#      |==> phusion/passenger-ruby22:0.9.17 -- https://goo.gl/xsnWOP
+#      |==> phusion/passenger-docker -- https://goo.gl/xsnWOP
 #           |==> HERE
-FROM phusion/passenger-ruby24:0.9.26
+FROM phusion/passenger-ruby24:0.9.35
 
 ENV APP_HOME=/home/app/pact_broker/
 RUN rm -f /etc/service/nginx/down /etc/nginx/sites-enabled/default
 COPY container /
-RUN gem update --system
-# USER app
+#USER app
 
-COPY pact_broker/config.ru pact_broker/Gemfile pact_broker/Gemfile.lock $APP_HOME
-# Update system gems for:
-# https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/
-RUN gem install bundler && \
-    cd $APP_HOME && bundle install --deployment --without='development test'
-COPY pact_broker/ $APP_HOME/
-RUN chown -R app:app $APP_HOME
+COPY --chown=app pact_broker/ $APP_HOME/
+RUN cd $APP_HOME && \
+    gem install --no-document --minimal-deps bundler && \
+    bundle install --deployment --without='development test' && \
+    rm -rf vendor/bundle/ruby/2.4.0/cache/ /usr/local/rvm/rubies/ruby-2.4.4/lib/ruby/gems/2.4.0/cache
 
 EXPOSE 80
 CMD ["/sbin/my_init"]


### PR DESCRIPTION
- use updated Phusion Ruby image so that Ruby gems won't need to
  be updated during Docker build
- clean Bundler and Ruby gems caches after installing dependencies
- copy with correct ownership instead of chown-ing after copying