### PR TITLE
Upgrade to latest phusion/passenger-ruby vers for security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# ubuntu:16.04 -- https://hub.docker.com/_/ubuntu/
-# |==> phusion/baseimage:0.9.17 -- https://goo.gl/ZLt61q
-#      |==> phusion/passenger-docker -- https://goo.gl/xsnWOP
+# ubuntu -- https://hub.docker.com/_/ubuntu/
+# |==> phusion/baseimage -- https://github.com/phusion/baseimage-docker
+#      |==> phusion/passenger-docker -- https://github.com/phusion/passenger-docker
 #           |==> HERE
-FROM phusion/passenger-ruby24:0.9.35
+FROM phusion/passenger-ruby24:1.0.0
 
 ENV APP_HOME=/home/app/pact_broker/
 RUN rm -f /etc/service/nginx/down /etc/nginx/sites-enabled/default


### PR DESCRIPTION
Based on our security scanner, various security issues have been fixed in the latest release phusion release, so we would like to upgrade. Let me know how I can help. Thank you!

Using `phusion/passenger-ruby24:1.0.0`:

Upgrades phusion/baseimage from 0.10.1 to 0.11: https://github.com/phusion/passenger-docker/commit/a25281f28142effce381e2d490b915a3372036f5#diff-bf6629b5c10beb732c7f409b270824c4

Which pulls in this upgrade from an Ubuntu release from April to a release from October: https://github.com/phusion/baseimage-docker/commit/5493db5179eb36451d87a46445fc7ee876110944#diff-bf6629b5c10beb732c7f409b270824c4