### PR TITLE
[do not merge] Start pactbroker as non-root on kubernetes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,9 @@ env:
     - PSQL_WAIT_TIMEOUT="20s"
     - PACT_CONT_NAME="broker_app"
     - PACT_WAIT_TIMEOUT="30s"
+    - PACT_BROKER_PORT=8080
   matrix:
-    - PACT_BROKER_PORT=80
+    - PACT_BROKER_PORT=8080
 #    - PACT_BROKER_PORT=9999
 
 # The test script is designed to run in a Linux machine and therefore

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,5 @@ RUN touch /etc/service/cron/down && chmod +x /etc/service/cron/down
 
 CMD ["/sbin/my_init"]
 
-# uid is 9999
-USER app
+# This is the user 'app'
+USER 9999

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,32 @@ RUN bash -lc 'rvm --default use ruby-2.4.5'
 ENV APP_HOME=/home/app/pact_broker/
 RUN rm -f /etc/service/nginx/down /etc/nginx/sites-enabled/default
 COPY container /
-#USER app
+
 
 COPY --chown=app pact_broker/ $APP_HOME/
+
 RUN cd $APP_HOME && \
     gem install --no-document --minimal-deps bundler && \
     bundle install --deployment --without='development test' && \
     rm -rf vendor/bundle/ruby/2.4.0/cache/ /usr/local/rvm/rubies/ruby-2.4.4/lib/ruby/gems/2.4.0/cache
 
-EXPOSE 80
+EXPOSE 8080
+
+# Adding 'app' user to group 'root'
+RUN set -ex && \
+    adduser app root
+
+# change file ownership to the group 'root' that should be acessible by user 'app'
+RUN chgrp -R 0 /etc/container_environment /etc/container_environment.sh /etc/container_environment.json /etc/syslog-ng /etc/runit/runsvdir /var/log/nginx /var/lib/nginx && \
+    chmod -R g+rwX /etc/container_environment /etc/container_environment.sh /etc/container_environment.json /etc/syslog-ng /etc/runit/runsvdir /var/log/nginx /var/lib/nginx
+RUN chown -R app:app /etc/runit/runsvdir /var/run/
+
+# Disabling syslog that needs to be run as root
+RUN rm -rf /etc/my_init.d/10_syslog-ng.init
+# Disabling cron that needs to be run as root
+RUN touch /etc/service/cron/down && chmod +x /etc/service/cron/down
+
 CMD ["/sbin/my_init"]
+
+# uid is 9999
+USER app

--- a/container/etc/nginx/sites-enabled/webapp.conf
+++ b/container/etc/nginx/sites-enabled/webapp.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     # server_name pact-broker;
     root /home/app/pact_broker/public;
 

--- a/container/usr/bin/loop_wait_pact.sh
+++ b/container/usr/bin/loop_wait_pact.sh
@@ -26,7 +26,7 @@ if ! jq --version >/dev/null 2>&1 ; then
 fi
 
 # defaults
-[ -z "${PACT_BROKER_PORT}" ] && PACT_BROKER_PORT=80
+[ -z "${PACT_BROKER_PORT}" ] && PACT_BROKER_PORT=8080
 [ -z "${PACT_BROKER_HOST}" ] && PACT_BROKER_HOST=localhost
 USERNAME="$1"
 PASSWORD="$2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,4 +37,4 @@ services:
       - ./ssl:/etc/nginx/ssl
     ports:
       - "8443:443"
-      - "80:80"
+      - "8080:8080"

--- a/script/test.sh
+++ b/script/test.sh
@@ -53,7 +53,7 @@ if [ "${TRAVIS}" == "true" ]; then
 fi
 
 # defaults
-[ -z "${PACT_BROKER_PORT}" ]             && PACT_BROKER_PORT=80
+[ -z "${PACT_BROKER_PORT}" ]             && PACT_BROKER_PORT=8080
 [ -z "${PSQL_WAIT_TIMEOUT}" ]            && PSQL_WAIT_TIMEOUT="10s"
 [ -z "${PACT_WAIT_TIMEOUT}" ]            && PACT_WAIT_TIMEOUT="15s"
 [ -z "${PACT_CONT_NAME}" ]               && PACT_CONT_NAME="broker-app"

--- a/ssl/nginx.conf
+++ b/ssl/nginx.conf
@@ -11,7 +11,7 @@ server {
   ssl_stapling_verify on;
 
   location / {
-      proxy_pass http://broker:80;
+      proxy_pass http://broker:8080;
       proxy_set_header Host $host;
       proxy_set_header X-Forwarded-Scheme "https";
       proxy_set_header X-Forwarded-Port "443";
@@ -21,11 +21,11 @@ server {
 }
 
 server {
-  listen      80 default_server;
+  listen      8080 default_server;
   server_name localhost;
 
   location / {
-      proxy_pass http://broker:80;
+      proxy_pass http://broker:8080;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
   }


### PR DESCRIPTION
#### Description
We have `pactbroker` running on our kubernets cluster currently as root using the image https://hub.docker.com/r/dius/pact-broker/dockerfile.
Our k8s admin want to enforce a security context configuration to have the pods all running as non-root.

Since the Docker `pact_broker-docker` image is based off `phusion/passenger-ruby24:1.0.0` which runs `CMD ["/sbin/my_init"]` which requires a root user for many things.
To workaround many issues (requiring root), I had to modify the Dockerfile to be able to run as non-root with user `app`:
* add the `app` user to the `root` group
* modified the ownerships of variaous files and directories 
* disabled syslog and cron (really not ideal...)
* expose 8080 port instead of port 80 from nginx

I tested this docker image with the k8s manifest configuration as follow:
### pactbroker.yml
```
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  labels:
    io.kompose.service: pact-broker
  name: pact-broker
  namespace: default
spec:
  ports:
  - name: "8080"
    port: 8080
    targetPort: 8080
  selector:
    io.kompose.service: pact-broker
  type: LoadBalancer

---

apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    io.kompose.service: pact-broker
  name: pact-broker
  namespace: default
spec:
  replicas: 1
  strategy: {}
  template:
    metadata:
      creationTimestamp: null
      labels:
        io.kompose.service: pact-broker
    spec:
      containers:
      - env:
        - name: PACT_BROKER_DATABASE_USERNAME
          value: postgres
        - name: PACT_BROKER_DATABASE_PASSWORD
          value: postgres
        - name: PACT_BROKER_DATABASE_HOST
          value: postgres
        - name: PACT_BROKER_DATABASE_NAME
          value: postgres
        - name: PACT_BROKER_PUBLIC_HEARTBEAT
          value: "true"
        # load docker image locally
        imagePullPolicy: Never
        image: my-pact-broker:latest
        name: pact-broker
        securityContext:
          runAsNonRoot: true
          runAsUser: 9999
        ports:
        - containerPort: 8080
        resources: {}
        livenessProbe:
          tcpSocket:
            port: 8080
          initialDelaySeconds: 30
          timeoutSeconds: 10
        readinessProbe:
          tcpSocket:
            port: 8080
          initialDelaySeconds: 30
          timeoutSeconds: 10
      restartPolicy: Always
```

### postgres.yml
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  creationTimestamp: null
  labels:
    io.kompose.service: postgres-claim0
  name: postgres-claim0
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 100Mi

---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    io.kompose.service: postgres
  name: postgres
  namespace: default
spec:
  replicas: 1
  strategy:
    type: Recreate
  template:
    metadata:
      creationTimestamp: null
      labels:
        io.kompose.service: postgres
    spec:
      containers:
      - env:
        - name: POSTGRES_PASSWORD
          value: postgres
        - name: POSTGRES_USER
          value: postgres
        image: postgres:9.6-alpine
        name: postgres
        resources: {}
        volumeMounts:
        - mountPath: /var/lib/postgresql/data
          name: postgres-claim0
      restartPolicy: Always
      volumes:
      - name: postgres-claim0
        persistentVolumeClaim:
          claimName: postgres-claim0

---
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: null
  labels:
    io.kompose.service: postgres
  name: postgres
  namespace: default
spec:
  clusterIP: None
  ports:
  - name: headless
    port: 55555
    targetPort: 0
  selector:
    io.kompose.service: postgres
```

### Running in kubernetes
```
$ kubectl apply -f pactbroker.yml
$ kubectl apply -f postgres.yml
$ kubectl get pods
NAME                          READY   STATUS    RESTARTS   AGE
pact-broker-ff9cf89fb-hmshw   1/1     Running   3          3h
postgres-57477d7cfc-j8pxn     1/1     Running   0          4d

$ kubectl logs pact-broker-ff9cf89fb-hmshw
*** Running /etc/my_init.d/00_regen_ssh_host_keys.sh...
*** Running /etc/my_init.d/30_presetup_nginx.sh...
*** Booting runit daemon...
*** Runit started as PID 8
ok: run: /etc/service/nginx-log-forwarder: (pid 14) 0s
nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:1
2019/03/11 20:45:41 [warn] 13#13: the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:1
[ N 2019-03-11 20:45:41.1556 16/T1 age/Wat/WatchdogMain.cpp:1366 ]: Starting Passenger watchdog...
[ N 2019-03-11 20:45:41.1752 19/T1 age/Cor/CoreMain.cpp:1339 ]: Starting Passenger core...
[ N 2019-03-11 20:45:41.1753 19/T1 age/Cor/CoreMain.cpp:256 ]: Passenger core running in multi-application mode.
[ N 2019-03-11 20:45:41.1871 19/T1 age/Cor/CoreMain.cpp:1014 ]: Passenger core online, PID 19
[ N 2019-03-11 20:45:43.7963 19/T5 age/Cor/SecurityUpdateChecker.h:519 ]: Security update check: no update found (next check in 24 hours)
App 53 output:  [passenger_native_support.so] trying to compile for the current user (app) and Ruby interpreter...
App 53 output:
App 53 output:      (set PASSENGER_COMPILE_NATIVE_SUPPORT_BINARY=0 to disable)
App 53 output:
App 53 output:      Compilation successful. The logs are here:
App 53 output:      /tmp/passenger_native_support-fkxkl3.log
App 53 output:  [passenger_native_support.so] successfully loaded.

$ curl localhost:8080
{"_links":{"self":{"href":"http://localhost:8080","title":"Index","templated":false},"pb:publish-pact":{"href":"http://localhost:8080/pacts/provider/{provider}/consumer/{consumer}/version/{consumerApplicationVersion}","title":"Publish a pact","templated":true},"pb:latest-pact-versions":{"href":"http://localhost:8080/pacts/latest","title":"Latest pact versions","templated":false},"pb:tagged-pact-versions":{"href":"http://localhost:8080/pacts/provider/{provider}/consumer/{consumer}/tag/{tag}","title":"All versions of a pact for a given consumer, provider and consumer version tag","templated":false},"pb:pacticipants":{"href":"http://localhost:8080/pacticipants","title":"Pacticipants","templated":false},"pb:latest-provider-pacts":{"href":"http://localhost:8080/pacts/provider/{provider}/latest","title":"Latest pacts by provider","templated":true},"pb:latest-provider-pacts-with-tag":{"href":"http://localhost:8080/pacts/provider/{provider}/latest/{tag}","title":"Latest pacts for provider with the specified tag","templated":true},"pb:provider-pacts-with-tag":{"href":"http://localhost:8080/pacts/provider/{provider}/tag/{tag}","title":"All pact versions for the provider with the specified consumer version tag","templated":true},"pb:provider-pacts":{"href":"http://localhost:8080/pacts/provider/{provider}","title":"All pact versions for the specified provider","templated":true},"pb:latest-version":{"href":"http://localhost:8080/pacticipants/{pacticipant}/latest-version","title":"Latest pacticipant version","templated":true},"pb:latest-tagged-version":{"href":"http://localhost:8080/pacticipants/{pacticipant}/latest-version/{tag}","title":"Latest pacticipant version with the specified tag","templated":true},"pb:webhooks":{"href":"http://localhost:8080/webhooks","title":"Webhooks","templated":false},"pb:integrations":{"href":"http://localhost:8080/integrations","title":"Integrations","templated":false},"beta:pending-provider-pacts":{"href":"http://localhost:8080/pacts/provider/{provider}/pending","title":"Pending pact versions for the specified provider","templated":true},"curies":[{"name":"pb","href":"http://localhost:8080/doc/{rel}?context=index","templated":true},{"name":"beta","href":"http://localhost:8080/doc/{rel}?context=index","templated":true}]}}
```