### PR TITLE
add cleanup steps for apt-get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,15 @@
 # |==> phusion/baseimage -- https://github.com/phusion/baseimage-docker
 #      |==> phusion/passenger-docker -- https://github.com/phusion/passenger-docker
 #           |==> HERE
-FROM phusion/passenger-ruby24:1.0.0
+FROM phusion/passenger-ruby24:1.0.5
 
 # Update OS as per https://github.com/phusion/passenger-docker#upgrading-the-operating-system-inside-the-container
-RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold"
+RUN apt-get update & \
+    apt-get upgrade -y -o Dpkg::Options::="--force-confold" & \
+    apt-get -qy autoremove & \
+    apt-get clean & \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 RUN bash -lc 'rvm --default use ruby-2.4.5'
 
 ENV APP_HOME=/home/app/pact_broker/


### PR DESCRIPTION
Added cleanup steps to reduce docker image size, by from 362.2 MB to 275.9 MB compressed and significantly more uncompressed. Also pulls down latest base image from 1.0.0 to 1.0.5 - phusion/passenger-ruby24:1.0.5


https://hub.docker.com/r/you54f/pact-broker-lite
https://microbadger.com/images/you54f/pact-broker-lite

https://hub.docker.com/r/dius/pact-broker/
https://microbadger.com/images/dius/pact-broker

image will always be upgraded to the latest ubuntu os and will have apt packages cleaned up. Addressing #34 and getting someway to address #52 