### PR TITLE
Increase client max body size in the nginx

### DIFF
--- a/container/etc/nginx/sites-enabled/webapp.conf
+++ b/container/etc/nginx/sites-enabled/webapp.conf
@@ -4,6 +4,7 @@ server {
 
     passenger_enabled on;
     passenger_user app;
+    client_max_body_size 200M;
 
     # If this is a Ruby app, specify a Ruby version:
     passenger_ruby /usr/bin/ruby;


### PR DESCRIPTION
### Changes: 
- Increase client max body size from 1m (default) to 200M.
`client_max_body_size: 200M;`

#### When send a file more than 1MB this error is displayed:
```
 Could not publish pact:
    Failed to publish ui/api pact due to error: PactBroker::Client::Error - <html>
    <head><title>413 Request Entity Too Large</title></head>
    <body bgcolor="white">
    <center><h1>413 Request Entity Too Large</h1></center>
    <hr><center>nginx/1.14.0 (Ubuntu)</center>
    </body>
    </html>
    One or more pacts failed to be published
```