### PR TITLE
Upgrade to latest phusion passenger ruby image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # |==> phusion/baseimage -- https://github.com/phusion/baseimage-docker
 #      |==> phusion/passenger-docker -- https://github.com/phusion/passenger-docker
 #           |==> HERE
-FROM phusion/passenger-ruby27:1.0.12
+FROM phusion/passenger-ruby27:2.0.1
 
 # Update OS as per https://github.com/phusion/passenger-docker#upgrading-the-operating-system-inside-the-container
 # Broken update https://github.com/DiUS/pact_broker-docker/runs/3799650621?check_suite_focus=true#step:9:87

--- a/Dockerfile-bundle-base
+++ b/Dockerfile-bundle-base
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby27:1.0.12
+FROM phusion/passenger-ruby27:2.0.1
 
 # Installation path
 ENV HOME=/pact_broker


### PR DESCRIPTION
### What
Upgrade to the latest phusion passenger ruby27 docker image. The latest tag is `2.01` as shown here: https://hub.docker.com/r/phusion/passenger-ruby27/tags

It looks like the changelog for the 1.x to 2.x release is here: https://github.com/phusion/passenger-docker/blob/master/CHANGELOG.md

### Why
2.x releases have a fix for this issue: https://github.com/phusion/passenger/issues/2303

We ran into this in the `dius/pact-broker:2.89.1.0` image: in that image running an apt-get update && upgrade runs into this error:
```
Reading package lists...                                                                                                                       
E: The repository 'https://oss-binaries.phusionpassenger.com/apt/passenger focal Release' does not have a Release file. 
```

