### PR TITLE
Upgrades: phusion passenger ruby image, ruby 2.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="2.89.1.0"></a>
+### 2.89.1.0 (2021-10-27)
+
+
+#### Features
+
+* **deps**
+  * update pact_broker gem to version 2.89.1	 ([ac7753f](/../../commit/ac7753f))
+
+
 <a name="2.89.0.0"></a>
 ### 2.89.0.0 (2021-10-15)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM phusion/passenger-ruby27:2.0.1
 #    apt-get clean && \
 #    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN bash -lc 'rvm --default use ruby-2.7.2'
+RUN bash -lc 'rvm --default use ruby-2.7.4'
 
 ENV APP_HOME=/home/app/pact_broker/
 WORKDIR $APP_HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # |==> phusion/baseimage -- https://github.com/phusion/baseimage-docker
 #      |==> phusion/passenger-docker -- https://github.com/phusion/passenger-docker
 #           |==> HERE
-FROM phusion/passenger-ruby27:1.0.12
+FROM phusion/passenger-ruby27:2.0.1
 
 # Update OS as per https://github.com/phusion/passenger-docker#upgrading-the-operating-system-inside-the-container
 # Broken update https://github.com/DiUS/pact_broker-docker/runs/3799650621?check_suite_focus=true#step:9:87

--- a/Dockerfile-bundle-base
+++ b/Dockerfile-bundle-base
@@ -1,4 +1,4 @@
-FROM phusion/passenger-ruby27:1.0.12
+FROM phusion/passenger-ruby27:2.0.1
 
 # Installation path
 ENV HOME=/pact_broker

--- a/Dockerfile-package-base
+++ b/Dockerfile-package-base
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine
+FROM ruby:2.7.4-alpine
 
 # Installation path
 ENV HOME=/app


### PR DESCRIPTION
Re-opening https://github.com/DiUS/pact_broker-docker/pull/111

### What
Upgrade to the latest phusion passenger ruby27 docker image. The latest tag is `2.01` as shown here: https://hub.docker.com/r/phusion/passenger-ruby27/tags

It looks like the changelog for the 1.x to 2.x release is here: https://github.com/phusion/passenger-docker/blob/master/CHANGELOG.md

### Why
2.x releases have a fix for this issue: https://github.com/phusion/passenger/issues/2303

We ran into this in the `dius/pact-broker:2.89.1.0` image: in that image running an apt-get update && upgrade runs into this error:
```
Reading package lists...                                                                                                                       
E: The repository 'https://oss-binaries.phusionpassenger.com/apt/passenger focal Release' does not have a Release file. 
```